### PR TITLE
Change health check to get caps

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -125,7 +125,7 @@ module "alb" {
   alb_name          = "${var.alb_name}"
   container_port    = "${var.container_port}"
   security_group    = "${data.aws_security_group.alb_sg.id}"
-  health_check_path = "/health"
+  health_check_path = "${var.health_check_path}"
 }
 
 # ==============

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -24,6 +24,11 @@ variable "docker_image" {
   description = "docker image to run"
 }
 
+variable "health_check_path" {
+  default     = "/?version=1.3.0&request=GetCapabilities&service=WMS"
+  description = "A path that returns 200OK if container is healthy"
+}
+
 variable "memory" {
   default     = 1024
   description = "memory for the container in MB"


### PR DESCRIPTION
Previous health check wasn't being monitored by the container forcing them to be destroyed. 
- Change /health to /?version=1.3.0&request=GetCapabilities&service=WMS
- Move health check to variable so it can be overwritten by tfvars.