### PR TITLE
split workspaces per service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,12 @@ install:
   - unzip terraform.zip && sudo mv terraform /usr/local/bin/terraform
   - terraform -v
 
+env:
+ - WORKSPACE=dev-s2-nrt
+
 script:
   - cd infrastructure
-  - terraform init
-  - terraform plan -input=false
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then terraform apply -auto-approve -input=false; fi'
+  - terraform init -backend-config workspaces/$WORKSPACE/backend.cfg
+  - terraform workspace new $WORKSPACE || terraform workspace select $WORKSPACE
+  - terraform plan -input=false -var-file="workspaces/$WORKSPACE/terraform.tfvars"
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then terraform apply -auto-approve -var-file="workspaces/$WORKSPACE/terraform.tfvars" -input=false; fi'

--- a/README.md
+++ b/README.md
@@ -21,15 +21,28 @@ We use the standard OpenDataCube containers defined [here](https://github.com/op
 ## Installation
 
 ### Change
+
+
+### Configuration
+ * Create a new folder in infrastructure/workspaces
+ * Copy the contents of another service and change the variables to suit
+ * In `backend.cfg`
+    * `bucket=$bucket` Should be an S3 bucket in your AWS Account
+    * `key=$cluster/$workspace/terraform.tfvars` Should match the cluster and directory name
+    * `region=$region` The region your S3 bucket lives in
+    * `dynamodb_table=$table` A table configured to act as a state lock
  * In `terraform.tfvars`
     * `cluster = $clustername` Should match the cluster you created using [terraform-ecs](https://github.com/GeoscienceAustralia/terraform-ecs)
     * `workspace = $workspacename` Unique name for this service on the cluster
     * `task_desired_count = $taskcount` Number of ECS tasks to run
 
 ### Creating
- * `terraform init`
- * `terraform plan`
- * `terraform apply`
+ * `export WORKSPACE=$workspace`
+ * `cd infrastructure`
+ * `terraform init -backend-config workspaces/$WORKSPACE/backend.cfg`
+ * `terraform workspace new $WORKSPACE || terraform workspace select $WORKSPACE`
+ * `terraform plan -var-file="workspaces/$WORKSPACE/terraform.tfvars`
+ * `terraform apply -var-file="workspaces/$WORKSPACE/terraform.tfvars"`
 
 ### Monitor logs
  * `awslogs get $cluster/$workspacename/$name --watch`

--- a/infrastructure/workspaces/dev-s2-nrt/backend.cfg
+++ b/infrastructure/workspaces/dev-s2-nrt/backend.cfg
@@ -1,0 +1,4 @@
+bucket="dea-devs-tfstate"
+key="datacube-ecs-default/dev-s2-nrt/terraform.tfstate"
+region="ap-southeast-2"
+dynamodb_table="terraform"

--- a/infrastructure/workspaces/dev-s2-nrt/terraform.tfvars
+++ b/infrastructure/workspaces/dev-s2-nrt/terraform.tfvars
@@ -1,0 +1,17 @@
+# The cluster you created using terraform-ecs
+cluster = "default"
+
+# The name of your project
+workspace = "dev-s2-nrt"
+
+# The number of containers to run at once
+task_desired_count = 2
+
+# The name of the database server
+database = "default-dev-mydb-rds"
+
+# The name of the service
+name = "datacube-wms"
+
+# The docker image to deploy
+docker_image = "opendatacube/wms:latest"


### PR DESCRIPTION
For each WMS:
- Load backend from backend.cfg
- Load vars from terraform.tfvars

Updated travis so we can easily add more deployments (adding additional WORKSPACE environment variables will trigger parallel deployments)