### PR TITLE
Run a once-off task

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -72,6 +72,7 @@ module "ecs_main" {
   task_role_name   = "${var.name}-role"
   target_group_arn = "${module.alb.alb_target_group}"
   account_id       = "${data.aws_caller_identity.current.account_id}"
+  webservice       = "${var.webservice}"
 
   # // container def
   container_definitions = <<EOF
@@ -102,7 +103,7 @@ module "ecs_main" {
       { "name": "DB_PORT", "value": "5432"},
       { "name": "VIRTUAL_HOST", "value": "localhost,127.0.0." }
     ],
-    "command" : ["gunicorn", "-b", "0.0.0.0:8000", "-w", "5", "--timeout", "300", "datacube_wms.wsgi"]
+    "command" : ["${join("\",\"",split(" ",var.docker_command))}"]
   }
 ]
 EOF
@@ -126,6 +127,7 @@ module "alb" {
   container_port    = "${var.container_port}"
   security_group    = "${data.aws_security_group.alb_sg.id}"
   health_check_path = "${var.health_check_path}"
+  webservice        = "${var.webservice}"
 }
 
 # ==============

--- a/infrastructure/modules/ecs/variables.tf
+++ b/infrastructure/modules/ecs/variables.tf
@@ -84,7 +84,7 @@ variable "parameter_store_resource" {
 ########
 
 variable "target_group_arn" {
-  type        = "string"
+  type        = "list"
   description = "ARN of the ELB's target group"
 }
 
@@ -109,4 +109,9 @@ variable "volume_name" {
 variable "container_definitions" {
   type        = "string"
   description = "JSON container definition"
+}
+
+variable "webservice" {
+  default     = true
+  description = "Whether the task should restart and be publically accessible"
 }

--- a/infrastructure/modules/load_balancer/main.tf
+++ b/infrastructure/modules/load_balancer/main.tf
@@ -1,6 +1,8 @@
 # Default ALB implementation that can be used connect ECS instances to it
 
 resource "aws_alb_target_group" "default" {
+  # only create if webservice is true
+  count                = "${var.webservice}"
   name                 = "${var.alb_name}"
   port                 = "${var.container_port}"
   protocol             = "HTTP"
@@ -25,6 +27,8 @@ resource "aws_alb_target_group" "default" {
 }
 
 resource "aws_alb" "alb" {
+  # only create if webservice is true
+  count           = "${var.webservice}"
   name            = "${var.alb_name}"
   subnets         = ["${var.public_subnet_ids}"]
   security_groups = ["${var.security_group}"]
@@ -39,6 +43,8 @@ resource "aws_alb" "alb" {
 }
 
 resource "aws_alb_listener" "http" {
+  # only create if webservice is true
+  count             = "${var.webservice}"
   load_balancer_arn = "${aws_alb.alb.id}"
   port              = 80
   protocol          = "HTTP"
@@ -52,7 +58,8 @@ resource "aws_alb_listener" "http" {
 }
 
 resource "aws_alb_listener" "https" {
-  count = "${var.enable_https}"
+  # only create if webservice and enable_https is true
+  count = "${var.enable_https * var.webservice}"
 
   load_balancer_arn = "${aws_alb.alb.id}"
   port              = 443

--- a/infrastructure/modules/load_balancer/outputs.tf
+++ b/infrastructure/modules/load_balancer/outputs.tf
@@ -1,13 +1,13 @@
 output "alb_target_group" {
-  value = "${aws_alb_target_group.default.arn}"
+  value = "${aws_alb_target_group.default.*.arn}"
 }
 
 output "alb_dns_name" {
-  value = "${aws_alb.alb.dns_name}"
+  value = "${aws_alb.alb.*.dns_name}"
 }
 
 output "alb_dns_zone_id" {
-  value = "${aws_alb.alb.zone_id}"
+  value = "${aws_alb.alb.*.zone_id}"
 }
 
 output "alb_name" {

--- a/infrastructure/modules/load_balancer/variables.tf
+++ b/infrastructure/modules/load_balancer/variables.tf
@@ -15,6 +15,11 @@ variable "service_name" {
   description = "The name of the service"
 }
 
+variable "webservice" {
+  default     = true
+  description = "Whether the task should restart and be publically accessible"
+}
+
 variable "owner" {
   description = "A mailing list that owns the service"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -19,9 +19,18 @@ variable "name" {
   description = "Name of the service"
 }
 
+variable "webservice" {
+  default     = true
+  description = "Whether the task should restart and be publically accessible"
+}
+
 variable "docker_image" {
   type        = "string"
   description = "docker image to run"
+}
+
+variable "docker_command" {
+  description = "Command to run on docker container"
 }
 
 variable "health_check_path" {

--- a/infrastructure/workspaces/dev-s2-nrt-db/backend.cfg
+++ b/infrastructure/workspaces/dev-s2-nrt-db/backend.cfg
@@ -1,0 +1,4 @@
+bucket="dea-devs-tfstate"
+key="datacube-ecs-default/dev-s2-nrt-db/terraform.tfstate"
+region="ap-southeast-2"
+dynamodb_table="terraform"

--- a/infrastructure/workspaces/dev-s2-nrt-db/terraform.tfvars
+++ b/infrastructure/workspaces/dev-s2-nrt-db/terraform.tfvars
@@ -2,19 +2,22 @@
 cluster = "default"
 
 # The name of your project
-workspace = "dev-s2-nrt"
+workspace = "dev-s2-nrt-db"
+
+# Setting this to false will turn off auto-restart and web access
+webservice = false
 
 # The number of containers to run at once
-task_desired_count = 2
+task_desired_count = 1
 
 # The name of the database server
 database = "default-dev-mydb-rds"
 
 # The name of the service
-name = "datacube-wms"
+name = "datacube-wms-db"
 
 # The docker image to deploy
-docker_image = "opendatacube/wms:latest"
+docker_image = "geoscienceaustralia/datacube-wms:aux_setup"
 
 # Command to run on the container
-docker_command = "gunicorn -b 0.0.0.0:8000 -w 5 --timeout 300 datacube_wms.wsgi"
+docker_command = "/bin/bash -c firsttime/setup.sh"


### PR DESCRIPTION
- Allow tasks to be run without adding an ALB
- Allow tasks to be run without restarting on complete/fail
- Add db task for prepping database
- Move docker command to variable to enable different use-cases