### PR TITLE
Move s3 access to standard policies

### DIFF
--- a/infrastructure/workspaces/dev-s2-nrt-index/terraform.tfvars
+++ b/infrastructure/workspaces/dev-s2-nrt-index/terraform.tfvars
@@ -30,24 +30,3 @@ environment_vars = {
 schedulable = true
 
 schedule_expression = "cron(1 0 * * ? *)"
-
-custom_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "GetFiles",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListObjects",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::dea-public-data",
-                "arn:aws:s3:::dea-public-data/*"
-            ]
-        }
-    ]
-}
-EOF

--- a/infrastructure/workspaces/dev-s2-nrt/terraform.tfvars
+++ b/infrastructure/workspaces/dev-s2-nrt/terraform.tfvars
@@ -37,24 +37,3 @@ enable_https = true
 ssl_cert_domain_name = "*.wms.gadevs.ga"
 
 ssl_cert_region = "ap-southeast-2"
-
-custom_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "GetFiles",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListObjects",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::dea-public-data",
-                "arn:aws:s3:::dea-public-data/*"
-            ]
-        }
-    ]
-}
-EOF

--- a/infrastructure/workspaces/s2-nrt-au-archive/terraform.tfvars
+++ b/infrastructure/workspaces/s2-nrt-au-archive/terraform.tfvars
@@ -31,24 +31,3 @@ environment_vars = {
 schedulable = true
 
 schedule_expression = "cron(1 15 * * ? *)"
-
-custom_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "GetFiles",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListObjects",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::dea-public-data",
-                "arn:aws:s3:::dea-public-data/*"
-            ]
-        }
-    ]
-}
-EOF

--- a/infrastructure/workspaces/s2-nrt-au-index/terraform.tfvars
+++ b/infrastructure/workspaces/s2-nrt-au-index/terraform.tfvars
@@ -30,24 +30,3 @@ environment_vars = {
 schedulable = true
 
 schedule_expression = "cron(1 14 * * ? *)"
-
-custom_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "GetFiles",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListObjects",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::dea-public-data",
-                "arn:aws:s3:::dea-public-data/*"
-            ]
-        }
-    ]
-}
-EOF

--- a/infrastructure/workspaces/s2-nrt-au/terraform.tfvars
+++ b/infrastructure/workspaces/s2-nrt-au/terraform.tfvars
@@ -22,7 +22,7 @@ docker_image = "opendatacube/wms:latest"
 docker_command = "gunicorn -b 0.0.0.0:8000 -w 4 --timeout 60 datacube_wms.wsgi"
 
 environment_vars = {
-  "WMS_CONFIG_URL"     = "https://raw.githubusercontent.com/opendatacube/datacube-ecs/master/infrastructure/workspaces/s2-nrt-au/wms_cfg.py"
+  "WMS_CONFIG_URL" = "https://raw.githubusercontent.com/opendatacube/datacube-ecs/master/infrastructure/workspaces/s2-nrt-au/wms_cfg.py"
 }
 
 # DNS address for the WMS service
@@ -41,24 +41,3 @@ enable_https = true
 ssl_cert_domain_name = "*.wms.gadevs.ga"
 
 ssl_cert_region = "ap-southeast-2"
-
-custom_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "GetFiles",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListObjects",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::dea-public-data",
-                "arn:aws:s3:::dea-public-data/*"
-            ]
-        }
-    ]
-}
-EOF


### PR DESCRIPTION
Simplify config by moving bucket access to the task role for each container.

This will add read access to db tasks, but as it's a public bucket I don't think that we should be worried about it.