### PR TITLE
move cloudwatch logs to match workspaces

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -76,7 +76,7 @@ module "container_def" {
 
   logging_options = {
     "awslogs-region" = "${var.aws_region}"
-    "awslogs-group"  = "${var.cluster}/${var.workspace}/${var.name}"
+    "awslogs-group"  = "${var.cluster}/apps/${terraform.workspace}"
   }
 
   port_mappings = [{

--- a/infrastructure/modules/ecs/main.tf
+++ b/infrastructure/modules/ecs/main.tf
@@ -215,7 +215,7 @@ resource "aws_iam_policy_attachment" "cw_logs" {
 }
 
 resource "aws_cloudwatch_log_group" "cw_logs" {
-  name = "${var.cluster}/${var.workspace}/${var.name}"
+  name = "${var.cluster}/apps/${terraform.workspace}"
 
   tags {
     Environment = "${var.workspace}"


### PR DESCRIPTION
This makes cloudwatch logs easier to find (enabling us to search logs programmatically)